### PR TITLE
fix: 로그인 리다이렉트 로직에서 엑세스 및 리프레시 토큰 참조 수정

### DIFF
--- a/user/views.py
+++ b/user/views.py
@@ -135,7 +135,7 @@ class Login(APIView):
                 refresh_token = str(token)
                 
                 # return HttpResponseRedirect(f"http://localhost:3000/login/redirection?isMember=true&accessToken={access_token}&refreshToken={refresh_token}")
-                return HttpResponseRedirect(f"https://www.mombo.site/login/redirection?isMember=true&accessToken={token.access}&refreshToken={token.refresh}")
+                return HttpResponseRedirect(f"https://www.mombo.site/login/redirection?isMember=true&accessToken={access_token}&refreshToken={refresh_token}")
             except User.DoesNotExist:
                 # return HttpResponseRedirect(f"http://localhost:3000/login/redirection?isMember=false&email={email}")
                 return HttpResponseRedirect(f"https://www.mombo.site/login/redirection?isMember=false&email={email}")


### PR DESCRIPTION
#2 

- `access_token` 및 `referesh_token` 변수를 사용하도록 업데이트
- `token.access` 대신 `access_token` 변수를 사용하도록 변경하고, `token.refresh`를 `refresh_token`으로 업데이트했습니다.

리다이렉트 변경 중 오류가 발생한 것 같습니다. 리뷰 후 머지해주시면 감사하겠습니다.